### PR TITLE
fix: Stabilize landing-page load — font CLS + single hero entrance (#73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ project_issues.md
 
 # playwright
 .playwright-mcp
+test-results/
+playwright-report/
+playwright/.cache/
 
 # vercel
 .vercel/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.47.0"
   },
   "dependencies": {
     "@astrojs/vercel": "^8.2.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for landing-page regression tests.
+ * Runs the Astro dev server and exercises the homepage in Chromium + WebKit.
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  // Generous per-test timeout: the dev server optimizes large portfolio images
+  // on demand, so a cold first navigation can be slow.
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,10 @@ importers:
       sharp:
         specifier: ^0.34.3
         version: 0.34.3
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.47.0
+        version: 1.62.1
 
 packages:
 
@@ -485,6 +489,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -1022,6 +1031,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1441,6 +1455,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2269,6 +2293,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@rollup/pluginutils@5.2.0(rollup@4.46.2)':
     dependencies:
       '@types/estree': 1.0.8
@@ -2828,6 +2856,9 @@ snapshots:
       motion-dom: 12.23.12
       motion-utils: 12.23.6
       tslib: 2.8.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3442,6 +3473,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.6:
     dependencies:

--- a/src/components/ui/HeaderAnimation.astro
+++ b/src/components/ui/HeaderAnimation.astro
@@ -33,8 +33,10 @@ const Tag = tag;
       this.syllables = [];
       this.syllablePositions = [];
       this.hasAnimated = false;
+      this.isReady = false;
+      this.pendingStart = false;
       this.observer = null;
-      
+
       if (this.headerEl) {
         this.init();
       }
@@ -42,9 +44,27 @@ const Tag = tag;
 
     async init() {
       if (!this.headerEl) return;
-      
+
+      // Measure syllable offsets against the real heading font, not the fallback.
+      // Splitting before the webfont is available reads stale metrics and lets
+      // the title FOIT-swap mid-animation. Gate on document.fonts.ready first.
+      if (document.fonts && document.fonts.ready) {
+        try {
+          await document.fonts.ready;
+        } catch {
+          /* fonts.ready can reject on some engines; fall through regardless */
+        }
+      }
+
       await this.splitTextIntoSyllables();
       this.setupIntersectionObserver();
+
+      // A reveal trigger (loadingComplete / intersection) may have fired while we
+      // were waiting for fonts. Honour it now that the syllables exist.
+      this.isReady = true;
+      if (this.pendingStart) {
+        this.startAnimation();
+      }
     }
 
     async splitTextIntoSyllables() {
@@ -90,10 +110,13 @@ const Tag = tag;
         { x: -containerWidth * 0.25, y: -35, name: 'N' }     // top-left (negative X)
       ];
 
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
       this.syllables.forEach((syllable, index) => {
         const position = this.syllablePositions[index];
-        if (position.name === 'SPACE') {
-          // Handle space differently - make it visible immediately
+        if (prefersReducedMotion || position.name === 'SPACE') {
+          // Reduced motion (and the space glyph) render statically at their final
+          // position with no scatter offset, so the title never shifts.
           syllable.style.opacity = '1';
           syllable.style.transform = 'translateX(0px) translateY(0px) scale(1)';
         } else {
@@ -223,7 +246,15 @@ const Tag = tag;
     }
     
     startAnimation() {
-      if (!this.hasAnimated) {
+      if (this.hasAnimated) return;
+
+      // Reveal was requested before the font-gated split finished; run it once ready.
+      if (!this.isReady) {
+        this.pendingStart = true;
+        return;
+      }
+
+      {
         const animationDelay = parseInt((this.headerEl && this.headerEl.getAttribute('data-animation-delay')) || '0');
         const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         setTimeout(() => {

--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -415,7 +415,8 @@ const organizationSchema = {
 
     /* Typography with Performance Optimization */
     --font-body: "ibm-plex-sans", "Montserrat", "Inter", sans-serif; /* Clean sans for body text */
-    --font-heading: "ivypresto-display", "Times New Roman", serif;
+    --font-heading: "ivypresto-display", "ivypresto-display-optimized",
+      "Times New Roman", serif;
     --font-sub-heading: "Lato", "Helvetica Neue", sans-serif;
     --font-lisbon-dev: "Unbounded", "Inter", sans-serif;
 
@@ -621,12 +622,30 @@ const organizationSchema = {
     outline: none;
   }
 
-  /* Performance-Optimized Font Loading */
+  /*
+   * Fallback-metrics face for the hero heading font.
+   *
+   * "ivypresto-display" (Adobe Typekit) has no font-display governance and its
+   * metrics differ from Times New Roman, so a plain fallback FOITs then reflows
+   * the hero title horizontally when the webfont swaps in. This face re-scales a
+   * locally-available serif to occupy the same footprint as ivypresto so the
+   * swap does not move the title. It is wired into --font-heading between the
+   * webfont and the generic serif fallback.
+   *
+   * NOTE: size-adjust / *-override are best-effort approximations of ivypresto's
+   * metrics (the webfont file is remote, so they were not measured directly).
+   * They can be fine-tuned against the live font with a tool like Fontaine.
+   * The hero uses a fixed unitless line-height (1.2), so the vertical overrides
+   * are largely inert here; size-adjust does the load-bearing horizontal work.
+   */
   @font-face {
     font-family: "ivypresto-display-optimized";
-    src: local("ivypresto-display"), local("Ivy Presto Display");
-    font-display: optional; /* Prevents layout shifts for hero content */
-    size-adjust: var(--font-fallback-size-adjust);
+    src: local("Times New Roman"), local("TimesNewRomanPSMT"), local("Times");
+    font-display: swap;
+    size-adjust: 95%;
+    ascent-override: 90%;
+    descent-override: 22%;
+    line-gap-override: 0%;
   }
 
   /* Hero Section Performance Optimization */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -282,27 +282,11 @@ const homeSEO = {
     align-items: center;
     
     /* Performance optimizations inherited from Layout.astro */
-    /* Animation setup for progressive enhancement */
+    /* The single hero entrance is the per-syllable Motion.js reveal in
+       HeaderAnimation.astro; the container stays static (no heroFadeIn) so the
+       two entrances don't overlap and the title doesn't translate on load. */
     opacity: 1;
     transform: translateY(0);
-  }
-
-  /* Progressive enhancement: Add animations only for capable devices */
-  @media (prefers-reduced-motion: no-preference) {
-    .hero-header {
-      animation: heroFadeIn 0.8s cubic-bezier(0.4, 0.0, 0.2, 1) forwards;
-    }
-  }
-
-  @keyframes heroFadeIn {
-    0% {
-      opacity: 0;
-      transform: translateY(20px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-    }
   }
 
   .hero-header > :global(.typography:first-child) {

--- a/tests/landing-cls.spec.ts
+++ b/tests/landing-cls.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression guard for issue #73 — landing-page load stability.
+ *
+ * The hero title used to reflow horizontally when the ivypresto-display webfont
+ * swapped in over the Times New Roman fallback. A fallback-metrics @font-face now
+ * keeps the fallback occupying the same footprint, so the swap must not move the
+ * title. We measure the title box early (fallback in use) and again after the
+ * heading font has finished loading, and assert it barely moves.
+ */
+test('hero title does not reflow horizontally when the heading font loads', async ({ page }) => {
+  // Wait only for the document, not every masonry image, so the image-heavy
+  // homepage doesn't time out the navigation on slower engines.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  const title = page.locator('.hero-title .animated-header').first();
+  await title.waitFor({ state: 'attached' });
+
+  // Capture the title box as early as possible — the fallback font is in use here.
+  const early = await title.boundingBox();
+  expect(early, 'hero title should have a layout box on load').not.toBeNull();
+
+  // Wait for the heading webfont to finish loading (or fail to). Bound the wait:
+  // on some engines document.fonts.ready re-pends while stylesheets stream in, so
+  // race it against a ceiling and measure afterwards either way.
+  await page.evaluate(
+    () =>
+      Promise.race([
+        (document as unknown as { fonts: { ready: Promise<unknown> } }).fonts.ready,
+        new Promise((resolve) => setTimeout(resolve, 8000)),
+      ]),
+  );
+
+  const late = await title.boundingBox();
+  expect(late, 'hero title should still have a layout box after fonts load').not.toBeNull();
+
+  const dx = Math.abs(late!.x - early!.x);
+  const dw = Math.abs(late!.width - early!.width);
+
+  // Fallback metrics should keep the font swap from reflowing the title.
+  expect(dx, `hero title left edge moved ${dx.toFixed(1)}px on font swap`).toBeLessThan(10);
+  expect(dw, `hero title width changed ${dw.toFixed(1)}px on font swap`).toBeLessThan(16);
+});
+
+/**
+ * There must be exactly one hero entrance animation. The duplicate CSS keyframe
+ * `heroFadeIn` (which translated the whole .hero-header at the same time as the
+ * per-syllable Motion.js reveal) was removed.
+ */
+test('the duplicate heroFadeIn entrance is gone', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  const hasHeroFadeIn = await page.evaluate(() => {
+    for (const sheet of Array.from(document.styleSheets)) {
+      let rules: CSSRuleList | undefined;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        continue; // cross-origin sheet, skip
+      }
+      if (!rules) continue;
+      for (const rule of Array.from(rules)) {
+        if (rule.cssText && rule.cssText.includes('heroFadeIn')) return true;
+      }
+    }
+    return false;
+  });
+
+  expect(hasHeroFadeIn, 'heroFadeIn keyframe/animation should no longer be defined').toBe(false);
+});


### PR DESCRIPTION
Implements #73 — heading-font CLS control (fallback metrics / font-display), gate hero reveal on document.fonts.ready, remove duplicate entrance animation. Adds Playwright CLS regression.

Fixes #73