### PR TITLE
fix: Re-init dialog & contact-form scripts on astro:page-load (#74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ project_issues.md
 
 # playwright
 .playwright-mcp
+test-results/
+playwright-report/
+playwright/.cache/
 
 # vercel
 .vercel/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
   },
   "dependencies": {
     "@astrojs/vercel": "^8.2.6",
@@ -16,5 +20,11 @@
     "motion": "^12.23.12",
     "resend": "^6.0.1",
     "sharp": "^0.34.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the portfolio.
+ * Runs `pnpm dev` and exercises the About/Contact modals after a view
+ * transition, in both Chromium and WebKit (Safari engine — see issue #74).
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 1,
+  // Dev-mode astro:assets optimizes each image on first request, so a cold
+  // homepage load can be slow; give tests headroom beyond the 30s default.
+  timeout: 60_000,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,10 @@ importers:
       sharp:
         specifier: ^0.34.3
         version: 0.34.3
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.62.1
 
 packages:
 
@@ -485,6 +489,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -1022,6 +1031,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1441,6 +1455,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2269,6 +2293,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@rollup/pluginutils@5.2.0(rollup@4.46.2)':
     dependencies:
       '@types/estree': 1.0.8
@@ -2828,6 +2856,9 @@ snapshots:
       motion-dom: 12.23.12
       motion-utils: 12.23.6
       tslib: 2.8.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3442,6 +3473,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.6:
     dependencies:

--- a/src/components/dialog/SimpleDialog.astro
+++ b/src/components/dialog/SimpleDialog.astro
@@ -299,10 +299,14 @@ const { id, class: className, contentAlign = "center" } = Astro.props;
 
 <script>
   // Enhance accessibility and functionality for dialogs
-  document.addEventListener("DOMContentLoaded", () => {
+  function initializeDialogs() {
     const dialogs = document.querySelectorAll(".simple-dialog");
 
     dialogs.forEach((dialog) => {
+      // Skip dialogs already initialized (idempotent across view transitions)
+      if ((dialog as HTMLElement).dataset.dialogInit === 'true') return;
+      (dialog as HTMLElement).dataset.dialogInit = 'true';
+
       // Observer for open/close state changes
       const observer = new MutationObserver(() => {
         const isOpen = dialog.hasAttribute('open');
@@ -358,7 +362,19 @@ const { id, class: className, contentAlign = "center" } = Astro.props;
           trigger.dataset.listenerAttached = 'true';
         }
       });
-      
+
     });
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeDialogs);
+  } else {
+    initializeDialogs();
+  }
+
+  // Re-run after every view transition (swapped-in DOM needs re-binding).
+  // Listen to both events: after-swap fires reliably on back/forward history
+  // navigation, page-load on forward navigation. init is idempotent.
+  document.addEventListener('astro:after-swap', initializeDialogs);
+  document.addEventListener('astro:page-load', initializeDialogs);
 </script>

--- a/src/components/forms/ContactForm.astro
+++ b/src/components/forms/ContactForm.astro
@@ -934,6 +934,9 @@ const subjectOptions = [
   function initializeContactForms(): void {
     const forms = document.querySelectorAll('[data-contact-form]') as NodeListOf<HTMLFormElement>;
     forms.forEach(form => {
+      // Skip forms already wrapped in a handler (idempotent across view transitions)
+      if (form.dataset.contactFormInit === 'true') return;
+      form.dataset.contactFormInit = 'true';
       new ContactFormHandler(form);
     });
   }
@@ -944,4 +947,10 @@ const subjectOptions = [
   } else {
     initializeContactForms();
   }
+
+  // Re-run after every view transition (swapped-in DOM needs re-binding).
+  // Listen to both events: after-swap fires reliably on back/forward history
+  // navigation, page-load on forward navigation. init is idempotent.
+  document.addEventListener('astro:after-swap', initializeContactForms);
+  document.addEventListener('astro:page-load', initializeContactForms);
 </script>

--- a/src/components/forms/FormMessage.astro
+++ b/src/components/forms/FormMessage.astro
@@ -183,22 +183,38 @@ if (!message) return null;
 
 <script>
   // Auto-dismiss success messages after a delay
-  document.addEventListener('DOMContentLoaded', () => {
+  function initializeFormMessages() {
     const successMessages = document.querySelectorAll('.form-message--success');
-    
+
     successMessages.forEach((message) => {
+      // Skip messages already scheduled for dismissal (idempotent across transitions)
+      if ((message as HTMLElement).dataset.formMessageInit === 'true') return;
+      (message as HTMLElement).dataset.formMessageInit = 'true';
+
       // Auto-dismiss after 5 seconds
       setTimeout(() => {
         if (message.parentNode) {
-          message.style.opacity = '0';
-          message.style.transform = 'translateY(-10px)';
-          message.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
-          
+          (message as HTMLElement).style.opacity = '0';
+          (message as HTMLElement).style.transform = 'translateY(-10px)';
+          (message as HTMLElement).style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+
           setTimeout(() => {
             message.remove();
           }, 300);
         }
       }, 5000);
     });
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeFormMessages);
+  } else {
+    initializeFormMessages();
+  }
+
+  // Re-run after every view transition (swapped-in DOM needs re-binding).
+  // Listen to both events: after-swap fires reliably on back/forward history
+  // navigation, page-load on forward navigation. init is idempotent.
+  document.addEventListener('astro:after-swap', initializeFormMessages);
+  document.addEventListener('astro:page-load', initializeFormMessages);
 </script>

--- a/tests/modal-after-nav.spec.ts
+++ b/tests/modal-after-nav.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Regression for issue #74 (Safari): the dialog/form scripts were bound only
+ * on DOMContentLoaded, so on the DOM swapped in by an Astro View Transition
+ * they were dead — the About/Contact modals opened (the Header uses inline
+ * onclick) but their scroll, inner buttons and multi-step form did nothing.
+ *
+ * Each test performs a real client-side navigation (a project link click, which
+ * the ClientRouter intercepts as a view transition) and then a history back
+ * (also a transition), landing on the swapped-in homepage before exercising the
+ * modals. Without the astro:after-swap / astro:page-load re-init, these fail.
+ */
+
+// A single logical navigation can emit several transition events in a burst
+// (Astro re-runs the ClientRouter for scroll restoration, so back navigation
+// fires before-preparation -> after-swap -> page-load more than once). Layout's
+// astro:before-preparation handler closes any open dialog, so opening one while
+// a navigation is still pending would immediately close it. We therefore wait
+// until no transition event has fired for 700ms before touching the modals.
+async function waitForTransitionsToSettle(page: Page) {
+  await page.waitForFunction(
+    () => Date.now() - ((window as any).__lastNav ?? 0) > 700,
+    undefined,
+    { timeout: 15_000 },
+  );
+}
+
+async function navigateAwayAndBack(page: Page) {
+  // domcontentloaded (not "load"): in dev, astro:assets optimizes each image on
+  // first request, so the image-heavy homepage never fires "load" quickly.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  // Track the last transition event. View transitions reuse the same document,
+  // so this instrumentation survives every subsequent swap.
+  await page.evaluate(() => {
+    (window as any).__lastNav = Date.now();
+    const bump = () => ((window as any).__lastNav = Date.now());
+    document.addEventListener('astro:before-preparation', bump);
+    document.addEventListener('astro:after-swap', bump);
+    document.addEventListener('astro:page-load', bump);
+  });
+
+  const projectLink = page.locator('a.project-link').first();
+  await projectLink.waitFor({ state: 'visible' });
+
+  // Forward: view transition into a project page.
+  await projectLink.click();
+  await page.waitForURL('**/projects/**');
+
+  // Back: ClientRouter handles popstate as a view transition too, swapping the
+  // homepage DOM (with its modals) back in.
+  await page.goBack();
+  await page.waitForURL((url) => url.pathname === '/');
+  await waitForTransitionsToSettle(page);
+  await page.locator('#about-dialog').waitFor({ state: 'attached' });
+}
+
+test.describe('modals remain functional after navigation (#74)', () => {
+  test('About dialog content-area scrolls via wheel after nav', async ({ page }) => {
+    // A short viewport guarantees the long About bio overflows and is scrollable.
+    await page.setViewportSize({ width: 1024, height: 600 });
+    await navigateAwayAndBack(page);
+
+    await page.evaluate(() => {
+      (document.getElementById('about-dialog') as HTMLDialogElement).showModal();
+    });
+
+    const contentArea = page.locator('#about-dialog .content-area');
+    await expect(contentArea).toBeVisible();
+
+    const box = await contentArea.boundingBox();
+    expect(box).not.toBeNull();
+
+    const scrollable = await contentArea.evaluate(
+      (el) => el.scrollHeight > el.clientHeight,
+    );
+    expect(scrollable, 'about content-area should overflow to be scrollable').toBe(true);
+
+    const before = await contentArea.evaluate((el) => el.scrollTop);
+
+    // Real (trusted) wheel over the content area. The component's wheel handler
+    // preventDefaults the event and drives .content-area.scrollTop itself; on
+    // WebKit a modal <dialog> only scrolls through this handler. If the handler
+    // wasn't re-bound after navigation, scrollTop never moves — the #74 bug.
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.wheel(0, 600);
+
+    await expect
+      .poll(async () => contentArea.evaluate((el) => el.scrollTop))
+      .toBeGreaterThan(before);
+  });
+
+  test('Contact trigger inside About opens the contact dialog after nav', async ({ page }) => {
+    await navigateAwayAndBack(page);
+
+    await page.evaluate(() => {
+      (document.getElementById('about-dialog') as HTMLDialogElement).showModal();
+    });
+
+    await page.locator('#about-dialog [data-dialog-trigger="contact-dialog"]').click();
+
+    await expect(page.locator('#contact-dialog[open]')).toBeAttached();
+  });
+
+  test('multi-step contact form submits successfully after nav', async ({ page }) => {
+    await page.route('**/api/contact', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    await navigateAwayAndBack(page);
+
+    await page.evaluate(() => {
+      (document.getElementById('contact-dialog') as HTMLDialogElement).showModal();
+    });
+
+    const form = page.locator('#contact-dialog [data-contact-form]');
+    await expect(form).toBeVisible();
+
+    // Step 1: name + email
+    await form.locator('[name="name"]').fill('Ada Lovelace');
+    await form.locator('[name="email"]').fill('ada@example.com');
+    await form.locator('[data-next-button]').click();
+
+    // Step 2: subject + message
+    await form.locator('[name="subject"]').selectOption({ index: 1 });
+    await form
+      .locator('[name="message"]')
+      .fill('This is a sufficiently long test message.');
+    await form.locator('[data-next-button]').click();
+
+    // Step 3: privacy consent + submit
+    await form.locator('[name="privacy_consent"]').check();
+    await form.locator('[data-submit-button]').click();
+
+    await expect(page.locator('#contact-dialog [data-success-message]')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Implements #74 — the SimpleDialog, ContactForm and FormMessage scripts bound their behavior only on `DOMContentLoaded`. With Astro View Transitions the DOM is swapped SPA-style and `DOMContentLoaded` never fires again, so after any client-side navigation the dialog wheel/scroll handlers, the contact-dialog trigger and the multi-step form handler were dead on the swapped-in markup. The Header's About/Contact buttons use inline `onclick` (which survives swaps), so the modal still opened but its scroll, inner buttons and form did nothing — Safari-only because Chrome/Firefox scroll the modal overflow container natively while Safari relies on the JS wheel handler.

### Fix
Each script is refactored to an idempotent `init()` that runs on DOM ready and re-runs on `astro:after-swap` **and** `astro:page-load` (matching the already-correct `Header` / `HeaderAnimation`). Per-element guards (`dialogInit` / `contactFormInit` / `formMessageInit`) prevent double-binding across repeated navigations. The Header inline `onclick` handlers are left untouched; no other behavior or styling changes.

Note: both `astro:after-swap` and `astro:page-load` are used because back/forward history navigation did not reliably emit `page-load` in testing, whereas `after-swap` fires on every swap.

### Tests
Adds a self-contained Playwright regression (`tests/modal-after-nav.spec.ts`, projects `chromium` + `webkit`): land on `/`, navigate into a project and back (real view transitions), then (a) assert the About `.content-area` scrolls on a real wheel, (b) the contact trigger opens `#contact-dialog[open]`, and (c) with `/api/contact` mocked, the multi-step form reaches its success state. **Verified the specs fail when the re-init is removed.** All 6 pass locally on chromium + webkit. `pnpm build` passes.

Fixes #74